### PR TITLE
leaderboard

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -42,6 +42,7 @@
         <button class="nav-tab active" id="nav-lobby">LOBBY</button>
         <button class="nav-tab" id="nav-locker">LOCKER</button>
         <button class="nav-tab" id="nav-stats">STATS</button>
+        <button class="nav-tab" id="nav-leaderboard">LEADERBOARD</button>
       </nav>
       <div class="user-profile-area">
         <img id="user-avatar-img" class="user-avatar-img" src="" alt="avatar" />
@@ -125,6 +126,14 @@
         <div class="stats-panel-inner">
           <div class="stats-panel-title">YOUR STATS</div>
           <div id="stats-panel-content" class="stats-grid-loading">Loading...</div>
+        </div>
+      </div>
+
+      <!-- ── Leaderboard panel ── -->
+      <div id="leaderboard-panel" class="hidden">
+        <div class="stats-panel-inner">
+          <div class="stats-panel-title">GLOBAL LEADERBOARD</div>
+          <div id="leaderboard-content" class="stats-grid-loading">Loading...</div>
         </div>
       </div>
 

--- a/client/src/auth.ts
+++ b/client/src/auth.ts
@@ -93,3 +93,21 @@ export async function fetchPlayerStats(clerkId: string): Promise<PlayerStats | n
     return null;
   }
 }
+
+export interface LeaderboardEntry {
+  username: string;
+  total_kills: number;
+  total_deaths: number;
+  total_wins: number;
+  total_games: number;
+}
+
+export async function fetchLeaderboard(): Promise<LeaderboardEntry[]> {
+  try {
+    const res = await fetch(`${SERVER_HTTP}/api/leaderboard`);
+    if (!res.ok) return [];
+    return await res.json() as LeaderboardEntry[];
+  } catch {
+    return [];
+  }
+}

--- a/client/src/lobby.ts
+++ b/client/src/lobby.ts
@@ -1,6 +1,6 @@
 import { CHARACTERS, ClassData } from './data/Classes';
 import { createRoom, joinAnyRoom, joinRoom } from './network/Network';
-import { requireAuth, saveUserToSupabase, getClerk, fetchPlayerStats, PlayerStats } from './auth';
+import { requireAuth, saveUserToSupabase, getClerk, fetchPlayerStats, fetchLeaderboard, PlayerStats, LeaderboardEntry } from './auth';
 
 const delay = (ms: number): Promise<void> => new Promise(r => setTimeout(r, ms));
 
@@ -334,13 +334,16 @@ function showLobby(username: string, resolve: (r: LobbyResult) => void, clerkId:
   const navLobby = document.getElementById('nav-lobby')!;
   const navLocker = document.getElementById('nav-locker')!;
   const navStats = document.getElementById('nav-stats')!;
+  const navLeaderboard = document.getElementById('nav-leaderboard')!;
   const lobbyStage = document.getElementById('lobby-stage')!;
   const lockerPanel = document.getElementById('locker-panel')!;
   const statsPanel = document.getElementById('stats-panel')!;
+  const leaderboardPanel = document.getElementById('leaderboard-panel')!;
   let lockerBuilt = false;
+  let leaderboardBuilt = false;
 
-  const allTabs = [navLobby, navLocker, navStats];
-  const allPanels = [lobbyStage, lockerPanel, statsPanel];
+  const allTabs = [navLobby, navLocker, navStats, navLeaderboard];
+  const allPanels = [lobbyStage, lockerPanel, statsPanel, leaderboardPanel];
 
   const switchTab = (activeTab: HTMLElement, activePanel: HTMLElement) => {
     allTabs.forEach(t => t.classList.remove('active'));
@@ -371,6 +374,15 @@ function showLobby(username: string, resolve: (r: LobbyResult) => void, clerkId:
   navStats.addEventListener('click', () => {
     playMenuClick();
     switchTab(navStats, statsPanel);
+  });
+
+  navLeaderboard.addEventListener('click', () => {
+    playMenuClick();
+    switchTab(navLeaderboard, leaderboardPanel);
+    if (!leaderboardBuilt) {
+      leaderboardBuilt = true;
+      void fetchLeaderboard().then(renderLeaderboardPanel);
+    }
   });
 
   let mode: 'host' | 'join' = 'host';
@@ -748,5 +760,51 @@ function renderStatsPanel(stats: PlayerStats | null, username: string, avatarUrl
         <div class="stats-card-lbl">WIN RATE</div>
       </div>
     </div>
+  `;
+}
+
+function renderLeaderboardPanel(entries: LeaderboardEntry[]): void {
+  const container = document.getElementById('leaderboard-content');
+  if (!container) return;
+
+  if (!entries.length) {
+    container.className = 'stats-empty';
+    container.innerHTML =
+      `<div class="stats-empty-icon">🏆</div>` +
+      `<p class="stats-empty-msg">No data yet.</p>` +
+      `<p class="stats-empty-sub">Play a game to get on the board!</p>`;
+    return;
+  }
+
+  container.className = '';
+  container.innerHTML = `
+    <table class="leaderboard-table">
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>PLAYER</th>
+          <th>KILLS</th>
+          <th>DEATHS</th>
+          <th>K/D</th>
+          <th>WINS</th>
+          <th>GAMES</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${entries.map((e, i) => {
+          const kd = (e.total_kills / Math.max(e.total_deaths, 1)).toFixed(2);
+          const medal = i === 0 ? '🥇' : i === 1 ? '🥈' : i === 2 ? '🥉' : `${i + 1}`;
+          return `<tr class="${i < 3 ? 'leaderboard-top' : ''}">
+            <td>${medal}</td>
+            <td>${e.username}</td>
+            <td>${e.total_kills}</td>
+            <td>${e.total_deaths}</td>
+            <td>${kd}</td>
+            <td>${e.total_wins}</td>
+            <td>${e.total_games}</td>
+          </tr>`;
+        }).join('')}
+      </tbody>
+    </table>
   `;
 }

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -534,7 +534,7 @@ html, body {
 /* ═══════════════════════════════════════
    STATS PANEL
 ═══════════════════════════════════════ */
-#stats-panel {
+#stats-panel, #leaderboard-panel {
   flex: 1; overflow-y: auto;
   padding: 32px 48px;
   background: rgba(10, 10, 10, 0.82);

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -610,6 +610,22 @@ html, body {
   font-size: 9px; color: #444456; letter-spacing: 2px;
   padding-top: 40px;
 }
+.leaderboard-table {
+  width: 100%; border-collapse: collapse; font-size: 11px; letter-spacing: 1px;
+}
+.leaderboard-table th {
+  color: #c41230; padding: 8px 12px; text-align: left;
+  border-bottom: 2px solid #c41230; letter-spacing: 2px;
+}
+.leaderboard-table td {
+  padding: 8px 12px; border-bottom: 1px solid #222238; color: #ccd;
+}
+.leaderboard-table .leaderboard-top td {
+  color: #fff;
+}
+.leaderboard-table tr:hover td {
+  background: #1a1a2e;
+}
 
 .locker-grid {
   display: grid;

--- a/my-server/src/app.config.ts
+++ b/my-server/src/app.config.ts
@@ -106,6 +106,27 @@ const server = defineServer({
             }
         });
 
+        // Global leaderboard — top 20 players by total kills
+        app.get("/api/leaderboard", async (_req: any, res: any) => {
+            try {
+                const rows = await prisma.playerStats.findMany({
+                    take: 20,
+                    orderBy: { totalKills: 'desc' },
+                    include: { user: { select: { username: true } } },
+                });
+                res.json(rows.map((r: any) => ({
+                    username:     r.user.username,
+                    total_kills:  r.totalKills,
+                    total_deaths: r.totalDeaths,
+                    total_wins:   r.totalWins,
+                    total_games:  r.totalGames,
+                })));
+            } catch (err) {
+                console.error("[api] /api/leaderboard error:", err);
+                res.status(500).json({ error: "Internal server error" });
+            }
+        });
+
         /**
          * Use @colyseus/monitor
          * It is recommended to protect this route with a password


### PR DESCRIPTION

Summary
Added a global leaderboard tab to the lobby UI, backed by a new server API endpoint.

Changes
Server

app.config.ts — new GET /api/leaderboard route returning top 20 players by total kills via Prisma
Client

auth.ts — fetchLeaderboard() function + LeaderboardEntry interface
index.html — LEADERBOARD nav tab + panel div
lobby.ts — leaderboard tab wiring + renderLeaderboardPanel() (lazy loads on first click)
style.css — leaderboard panel and table styles
Test plan
 Click LEADERBOARD tab in lobby — should show "No data yet" if DB is empty
 After a completed game, leaderboard should populate with player stats sorted by kills
 Top 3 players show medal emojis (🥇🥈🥉)
 Rows beyond top 3 show rank number
