### PR TITLE
Add 3-column leaderboard + tighten host-row layout

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -108,6 +108,8 @@
           <div class="panel-title">CAMPUS<br>CLASH</div>
           <div class="panel-divider"></div>
 
+          <div id="online-count"><span class="count-value">—</span> PLAYERS ONLINE</div>
+
           <div class="mode-selector">
             <button class="mode-btn active" id="host-btn">HOST</button>
             <button class="mode-btn" id="join-btn">JOIN</button>

--- a/client/index.html
+++ b/client/index.html
@@ -117,31 +117,41 @@
 
           <!-- HOST sub-options -->
           <div id="host-options" class="sub-options">
-            <button class="sub-btn active" id="public-btn">PUBLIC</button>
-            <button class="sub-btn" id="private-btn">PRIVATE</button>
-            <span class="sub-label">MODE:</span>
-            <div class="game-mode-selector">
-              <button class="game-mode-btn active" id="ffa-btn">FREEPLAY</button>
-              <button class="game-mode-btn" id="kc-btn">KILL CONFIRMED</button>
+            <div class="host-row">
+              <button class="sub-btn active" id="public-btn">PUBLIC</button>
+              <button class="sub-btn" id="private-btn">PRIVATE</button>
             </div>
-            <span class="max-players-label">MAX:</span>
-            <div class="player-count-selector">
-              <button class="player-count-btn" id="mp-5">5</button>
-              <button class="player-count-btn active" id="mp-10">10</button>
-              <button class="player-count-btn" id="mp-20">20</button>
-              <button class="player-count-btn" id="mp-30">30</button>
+            <div class="host-row">
+              <span class="sub-label">MODE:</span>
+              <div class="game-mode-selector">
+                <button class="game-mode-btn active" id="ffa-btn">FREEPLAY</button>
+                <button class="game-mode-btn" id="kc-btn">KILL CONFIRMED</button>
+              </div>
             </div>
-            <span class="max-players-label">TIME:</span>
-            <div class="player-count-selector">
-              <button class="player-count-btn" id="dur-120">2 MIN</button>
-              <button class="player-count-btn" id="dur-180">3 MIN</button>
-              <button class="player-count-btn active" id="dur-300">5 MIN</button>
+            <div class="host-row">
+              <span class="max-players-label">MAX:</span>
+              <div class="player-count-selector">
+                <button class="player-count-btn" id="mp-5">5</button>
+                <button class="player-count-btn active" id="mp-10">10</button>
+                <button class="player-count-btn" id="mp-20">20</button>
+                <button class="player-count-btn" id="mp-30">30</button>
+              </div>
             </div>
-            <span class="max-players-label">ITEMS:</span>
-            <div class="player-count-selector">
-              <button class="player-count-btn" id="dens-1">FEW</button>
-              <button class="player-count-btn active" id="dens-2">NORMAL</button>
-              <button class="player-count-btn" id="dens-4">MANY</button>
+            <div class="host-row">
+              <span class="max-players-label">TIME:</span>
+              <div class="player-count-selector">
+                <button class="player-count-btn" id="dur-120">2 MIN</button>
+                <button class="player-count-btn" id="dur-180">3 MIN</button>
+                <button class="player-count-btn active" id="dur-300">5 MIN</button>
+              </div>
+            </div>
+            <div class="host-row">
+              <span class="max-players-label">ITEMS:</span>
+              <div class="player-count-selector">
+                <button class="player-count-btn" id="dens-1">FEW</button>
+                <button class="player-count-btn active" id="dens-2">NORMAL</button>
+                <button class="player-count-btn" id="dens-4">MANY</button>
+              </div>
             </div>
           </div>
 

--- a/client/src/auth.ts
+++ b/client/src/auth.ts
@@ -211,6 +211,15 @@ export interface LeaderboardEntry {
   total_deaths: number;
   total_wins: number;
   total_games: number;
+  ffa_kills?: number;
+  ffa_deaths?: number;
+  ffa_wins?: number;
+  ffa_games?: number;
+  kc_confirms?: number;
+  kc_kills?: number;
+  kc_deaths?: number;
+  kc_wins?: number;
+  kc_games?: number;
 }
 
 export async function fetchLeaderboard(): Promise<LeaderboardEntry[]> {

--- a/client/src/entities/Player.ts
+++ b/client/src/entities/Player.ts
@@ -195,23 +195,43 @@ export class Player {
     }
 
     const dist = this.speed * speedMult * (delta / 1000);
-    const newX = this.sprite.x + moveX * dist;
-    const newY = this.sprite.y + moveY * dist;
-
     const half = 15; // accurate to 32px sprite (±16), 1px inset
 
-    if (this.canMove(newX, this.sprite.y, half)) {
-      this.sprite.x = newX;
-      this.bounceRemainX = 0;
-    } else if (isMoving && !this.isDashing) {
-      this.bounceRemainX = -moveX * Player.BOUNCE_DIST;
+    // Sub-step movement so fast moves (dash, frame drops) can't skip past
+    // a thin wall tile in one frame. Each sub-step is ≤ 8px (half a tile).
+    const MAX_STEP = 8;
+    const numSteps = Math.max(1, Math.ceil(dist / MAX_STEP));
+    const stepX = (moveX * dist) / numSteps;
+    const stepY = (moveY * dist) / numSteps;
+
+    let xMoved = false;
+    let yMoved = false;
+    let xBlocked = false;
+    let yBlocked = false;
+    for (let i = 0; i < numSteps; i++) {
+      if (!xBlocked) {
+        if (this.canMove(this.sprite.x + stepX, this.sprite.y, half)) {
+          this.sprite.x += stepX;
+          xMoved = true;
+        } else {
+          xBlocked = true;
+        }
+      }
+      if (!yBlocked) {
+        if (this.canMove(this.sprite.x, this.sprite.y + stepY, half)) {
+          this.sprite.y += stepY;
+          yMoved = true;
+        } else {
+          yBlocked = true;
+        }
+      }
+      if (xBlocked && yBlocked) break;
     }
-    if (this.canMove(this.sprite.x, newY, half)) {
-      this.sprite.y = newY;
-      this.bounceRemainY = 0;
-    } else if (isMoving && !this.isDashing) {
-      this.bounceRemainY = -moveY * Player.BOUNCE_DIST;
-    }
+
+    if (xMoved) this.bounceRemainX = 0;
+    else if (isMoving && !this.isDashing) this.bounceRemainX = -moveX * Player.BOUNCE_DIST;
+    if (yMoved) this.bounceRemainY = 0;
+    else if (isMoving && !this.isDashing) this.bounceRemainY = -moveY * Player.BOUNCE_DIST;
 
     // Step toward remaining bounce distance at fixed speed
     const maxStep = Player.BOUNCE_SPEED * (delta / 1000);
@@ -237,7 +257,7 @@ export class Player {
     }
   }
 
-  private canMove(px: number, py: number, half: number): boolean {
+  canMove(px: number, py: number, half: number): boolean {
     const corners = [
       { x: px - half, y: py - half },
       { x: px + half, y: py - half },
@@ -250,6 +270,10 @@ export class Player {
       if (!isWalkable(tx, ty)) return false;
     }
     return true;
+  }
+
+  isStuckInWall(): boolean {
+    return !this.canMove(this.sprite.x, this.sprite.y, 15);
   }
 
   dash(time: number): void {

--- a/client/src/lobby.ts
+++ b/client/src/lobby.ts
@@ -671,15 +671,17 @@ function showLobby(username: string, resolve: (r: LobbyResult) => void, clerkId:
   });
 
   // ── Live online player count (lobby + in-game) ──
-  void joinLobbyPresence();
   const onlineCountEl = document.querySelector<HTMLElement>('#online-count .count-value');
   async function refreshOnlineCount() {
     if (!onlineCountEl) return;
     const total = await getOnlineCount();
     onlineCountEl.textContent = String(total);
   }
+  // Kick off presence join + an eager first fetch in parallel; when the join
+  // resolves, refresh again so the bump from the current user shows immediately.
+  void joinLobbyPresence().then(() => { void refreshOnlineCount(); });
   void refreshOnlineCount();
-  const onlineCountInterval = window.setInterval(refreshOnlineCount, 5000);
+  const onlineCountInterval = window.setInterval(refreshOnlineCount, 2000);
 
   // ── Browse rooms ──
   const browseBtn = document.getElementById('browse-btn');

--- a/client/src/lobby.ts
+++ b/client/src/lobby.ts
@@ -670,6 +670,22 @@ function showLobby(username: string, resolve: (r: LobbyResult) => void, clerkId:
     joinStatus.textContent = '';
   });
 
+  // ── Live online player count ──
+  const onlineCountEl = document.querySelector<HTMLElement>('#online-count .count-value');
+  async function refreshOnlineCount() {
+    if (!onlineCountEl) return;
+    try {
+      const { getAvailableRooms } = await import('./network/Network');
+      const rooms = await getAvailableRooms();
+      const total = rooms.reduce((sum: number, r: any) => sum + (r.clients || 0), 0);
+      onlineCountEl.textContent = String(total);
+    } catch {
+      // silent — keep last known value
+    }
+  }
+  void refreshOnlineCount();
+  const onlineCountInterval = window.setInterval(refreshOnlineCount, 5000);
+
   // ── Browse rooms ──
   const browseBtn = document.getElementById('browse-btn');
   const roomBrowser = document.getElementById('room-browser');
@@ -760,6 +776,7 @@ function showLobby(username: string, resolve: (r: LobbyResult) => void, clerkId:
 
     const launchGame = async () => {
       if (browserInterval) { clearInterval(browserInterval); browserInterval = undefined; }
+      clearInterval(onlineCountInterval);
       playBtn.textContent = 'Game Found';
       playBtn.style.color = '#2ecc71';
       await delay(1000);

--- a/client/src/lobby.ts
+++ b/client/src/lobby.ts
@@ -944,35 +944,58 @@ function renderLeaderboardPanel(entries: LeaderboardEntry[]): void {
     return;
   }
 
-  container.className = '';
-  container.innerHTML = `
-    <table class="leaderboard-table">
-      <thead>
-        <tr>
-          <th>#</th>
-          <th>PLAYER</th>
-          <th>KILLS</th>
-          <th>DEATHS</th>
-          <th>K/D</th>
-          <th>WINS</th>
-          <th>GAMES</th>
-        </tr>
-      </thead>
-      <tbody>
-        ${entries.map((e, i) => {
-          const kd = (e.total_kills / Math.max(e.total_deaths, 1)).toFixed(2);
-          const medal = i === 0 ? '🥇' : i === 1 ? '🥈' : i === 2 ? '🥉' : `${i + 1}`;
-          return `<tr class="${i < 3 ? 'leaderboard-top' : ''}">
-            <td>${medal}</td>
+  const topN = 10;
+  const medal = (i: number) => i === 0 ? '🥇' : i === 1 ? '🥈' : i === 2 ? '🥉' : `${i + 1}`;
+  const val = (e: LeaderboardEntry, k: keyof LeaderboardEntry) => (e[k] as number) ?? 0;
+
+  const makeTable = (
+    title: string,
+    sortKey: keyof LeaderboardEntry,
+    cols: { label: string; key: keyof LeaderboardEntry }[],
+  ) => {
+    const sorted = [...entries]
+      .sort((a, b) => val(b, sortKey) - val(a, sortKey))
+      .filter(e => val(e, sortKey) > 0)
+      .slice(0, topN);
+
+    if (!sorted.length) {
+      return `<div class="leaderboard-col">
+        <div class="leaderboard-col-title">${title}</div>
+        <div class="leaderboard-empty">No games played yet</div>
+      </div>`;
+    }
+
+    return `<div class="leaderboard-col">
+      <div class="leaderboard-col-title">${title}</div>
+      <table class="leaderboard-table">
+        <thead><tr><th>#</th><th>PLAYER</th>${cols.map(c => `<th>${c.label}</th>`).join('')}</tr></thead>
+        <tbody>
+          ${sorted.map((e, i) => `<tr class="${i < 3 ? 'leaderboard-top' : ''}">
+            <td>${medal(i)}</td>
             <td>${e.username}</td>
-            <td>${e.total_kills}</td>
-            <td>${e.total_deaths}</td>
-            <td>${kd}</td>
-            <td>${e.total_wins}</td>
-            <td>${e.total_games}</td>
-          </tr>`;
-        }).join('')}
-      </tbody>
-    </table>
-  `;
+            ${cols.map(c => `<td>${val(e, c.key)}</td>`).join('')}
+          </tr>`).join('')}
+        </tbody>
+      </table>
+    </div>`;
+  };
+
+  container.className = 'leaderboard-grid';
+  container.innerHTML =
+    makeTable('FREEPLAY', 'ffa_kills', [
+      { label: 'K', key: 'ffa_kills' },
+      { label: 'D', key: 'ffa_deaths' },
+      { label: 'W', key: 'ffa_wins' },
+    ]) +
+    makeTable('KILL CONFIRMED', 'kc_confirms', [
+      { label: 'CONF', key: 'kc_confirms' },
+      { label: 'D',    key: 'kc_deaths' },
+      { label: 'W',    key: 'kc_wins' },
+    ]) +
+    makeTable('OVERALL', 'total_kills', [
+      { label: 'K', key: 'total_kills' },
+      { label: 'D', key: 'total_deaths' },
+      { label: 'W', key: 'total_wins' },
+      { label: 'G', key: 'total_games' },
+    ]);
 }

--- a/client/src/lobby.ts
+++ b/client/src/lobby.ts
@@ -1,5 +1,5 @@
 import { CHARACTERS, ClassData } from './data/Classes';
-import { createRoom, joinAnyRoom, joinRoom } from './network/Network';
+import { createRoom, joinAnyRoom, joinRoom, joinLobbyPresence, leaveLobbyPresence, getOnlineCount } from './network/Network';
 import { requireAuth, saveUserToSupabase, getClerk, fetchPlayerStats, fetchLeaderboard, PlayerStats, LeaderboardEntry } from './auth';
 
 const delay = (ms: number): Promise<void> => new Promise(r => setTimeout(r, ms));
@@ -670,18 +670,13 @@ function showLobby(username: string, resolve: (r: LobbyResult) => void, clerkId:
     joinStatus.textContent = '';
   });
 
-  // ── Live online player count ──
+  // ── Live online player count (lobby + in-game) ──
+  void joinLobbyPresence();
   const onlineCountEl = document.querySelector<HTMLElement>('#online-count .count-value');
   async function refreshOnlineCount() {
     if (!onlineCountEl) return;
-    try {
-      const { getAvailableRooms } = await import('./network/Network');
-      const rooms = await getAvailableRooms();
-      const total = rooms.reduce((sum: number, r: any) => sum + (r.clients || 0), 0);
-      onlineCountEl.textContent = String(total);
-    } catch {
-      // silent — keep last known value
-    }
+    const total = await getOnlineCount();
+    onlineCountEl.textContent = String(total);
   }
   void refreshOnlineCount();
   const onlineCountInterval = window.setInterval(refreshOnlineCount, 5000);
@@ -777,6 +772,7 @@ function showLobby(username: string, resolve: (r: LobbyResult) => void, clerkId:
     const launchGame = async () => {
       if (browserInterval) { clearInterval(browserInterval); browserInterval = undefined; }
       clearInterval(onlineCountInterval);
+      leaveLobbyPresence();
       playBtn.textContent = 'Game Found';
       playBtn.style.color = '#2ecc71';
       await delay(1000);

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -18,7 +18,7 @@ initLobby().catch((err) => console.error('[CC] initLobby failed:', err)).then(({
     scene: [GameScene, HUDScene],
     scale: {
       mode: Phaser.Scale.FIT,
-      autoCenter: Phaser.Scale.CENTER_BOTH,
+      autoCenter: Phaser.Scale.CENTER_HORIZONTALLY,
     },
   };
 

--- a/client/src/network/Network.ts
+++ b/client/src/network/Network.ts
@@ -148,6 +148,52 @@ export async function getAvailableRooms(): Promise<any[]> {
   return Array.isArray(data) ? data : [];
 }
 
+export async function getOnlineCount(): Promise<number> {
+  const httpUrl = SERVER_URL.replace('wss://', 'https://').replace('ws://', 'http://');
+  try {
+    const res = await fetch(`${httpUrl}/api/online`);
+    const data = await res.json();
+    return typeof data?.total === 'number' ? data.total : 0;
+  } catch {
+    return 0;
+  }
+}
+
+let lobbyPresenceRoom: Room | undefined;
+let lobbyPresencePending = false;
+let lobbyShouldLeave = false;
+
+export async function joinLobbyPresence(): Promise<void> {
+  if (lobbyPresenceRoom || lobbyPresencePending) return;
+  lobbyPresencePending = true;
+  lobbyShouldLeave = false;
+  try {
+    const c = initClient();
+    const room = await c.joinOrCreate('lobby_room');
+    if (lobbyShouldLeave) {
+      // leave() was called while we were connecting — disconnect immediately
+      try { room.leave(true); } catch {}
+    } else {
+      lobbyPresenceRoom = room;
+      room.onLeave(() => { lobbyPresenceRoom = undefined; });
+    }
+  } catch (err) {
+    console.warn('lobby presence join failed', err);
+  } finally {
+    lobbyPresencePending = false;
+  }
+}
+
+export function leaveLobbyPresence(): void {
+  if (lobbyPresencePending) {
+    lobbyShouldLeave = true;
+    return;
+  }
+  if (!lobbyPresenceRoom) return;
+  try { lobbyPresenceRoom.leave(true); } catch {}
+  lobbyPresenceRoom = undefined;
+}
+
 export async function joinRoomById(roomId: string, name: string, spriteKey = 'adventurer', clerkId = ''): Promise<Room> {
   const c = initClient();
   const r = await c.joinById(roomId, { name, spriteKey, clerkId });

--- a/client/src/scenes/GameScene.ts
+++ b/client/src/scenes/GameScene.ts
@@ -871,9 +871,11 @@ export class GameScene extends Phaser.Scene {
         this.lastSendTime = time;
       }
 
-      // Player-to-player collision: push local player out of remote player bodies
+      // Player-to-player collision: push local player out of remote player bodies,
+      // but validate against tile collision so we never land inside a wall.
       if (this.gamePhase === 'playing') {
         const MIN_DIST = 28; // ~2× the half-size of a player sprite (14px radius each)
+        const half = 15;
         this.remotePlayers.forEach(rp => {
           if (!rp.alive) return;
           const dx = this.player.sprite.x - rp.sprite.x;
@@ -882,10 +884,25 @@ export class GameScene extends Phaser.Scene {
           if (distSq > 0 && distSq < MIN_DIST * MIN_DIST) {
             const dist = Math.sqrt(distSq);
             const push = (MIN_DIST - dist) / dist;
-            this.player.sprite.x += dx * push;
-            this.player.sprite.y += dy * push;
+            const pushX = dx * push;
+            const pushY = dy * push;
+            // Axis-split so we can still slide along a wall when pushed against it.
+            if (this.player.canMove(this.player.sprite.x + pushX, this.player.sprite.y, half)) {
+              this.player.sprite.x += pushX;
+            }
+            if (this.player.canMove(this.player.sprite.x, this.player.sprite.y + pushY, half)) {
+              this.player.sprite.y += pushY;
+            }
           }
         });
+      }
+
+      // Unstick safety net — if we somehow ended up inside a blocked tile
+      // (dash at a network spike, bitmask desync, etc), snap to the nearest safe tile.
+      if (this.gamePhase === 'playing' && this.player.alive && this.player.isStuckInWall()) {
+        const safe = findSafeSpawn(this.player.sprite.x, this.player.sprite.y);
+        this.player.sprite.x = safe.x;
+        this.player.sprite.y = safe.y;
       }
     }
 

--- a/client/src/scenes/HUDScene.ts
+++ b/client/src/scenes/HUDScene.ts
@@ -129,7 +129,7 @@ export class HUDScene extends Phaser.Scene {
     }).setOrigin(0.5).setVisible(false);
 
     // Controls legend
-    this.controlsText = this.add.text(width / 2, height - 28, 'WASD: Move  |  O: Attack  |  SPACE: Dash  |  P: Fireball', {
+    this.controlsText = this.add.text(width / 2, height - 48, 'WASD: Move  |  O: Attack  |  SPACE: Dash  |  P: Fireball', {
       fontFamily: 'Courier New, monospace',
       fontSize: '18px',
       color: '#a8dadc',
@@ -155,7 +155,7 @@ export class HUDScene extends Phaser.Scene {
     }).setVisible(false);
 
     // Room status (bottom left) — visible during both phases
-    this.roomCodeText = this.add.text(16, height - 60, '', {
+    this.roomCodeText = this.add.text(16, height - 80, '', {
       fontFamily: 'Courier New, monospace',
       fontSize: '22px',
       color: '#00ff00',
@@ -186,7 +186,7 @@ export class HUDScene extends Phaser.Scene {
     this.mmContainer.setVisible(false);
 
     // Return to lobby button (always visible)
-    this.lobbyBtn = this.createButton(width - 172, height - 60, '← LOBBY', 0x1a3a7a, () => {
+    this.lobbyBtn = this.createButton(width - 172, height - 80, '← LOBBY', 0x1a3a7a, () => {
       leaveRoom();
       window.location.reload();
     });
@@ -351,7 +351,7 @@ export class HUDScene extends Phaser.Scene {
     this.roomCodeText.setText(`ROOM: ${roomCode}`).setColor('#00ff00');
 
     // Copy code button next to room code (all players)
-    const copyBtn = this.createButton(164, height - 36, 'COPY CODE', 0x1a4a2a, () => {
+    const copyBtn = this.createButton(164, height - 56, 'COPY CODE', 0x1a4a2a, () => {
       navigator.clipboard.writeText(this.currentRoomCode).then(() => {
         this.roomCodeText.setText('COPIED!').setColor('#f5c518');
         this.time.delayedCall(1500, () => {
@@ -809,7 +809,7 @@ export class HUDScene extends Phaser.Scene {
   private createInventoryBox(): void {
     const { width, height } = this.scale;
     const cx = width / 2;
-    const cy = height - 72;
+    const cy = height - 92;
 
     const container = this.add.container(cx, cy);
     container.setDepth(10).setScrollFactor(0);
@@ -932,7 +932,7 @@ export class HUDScene extends Phaser.Scene {
     const weaponLabel = weapon === 'fireball' ? 'Fireball' : 'Melee';
     const msg = `${killerName}  [${weaponLabel}]  ${victimName}`;
 
-    const text = this.add.text(width - 16, height - 70, msg, {
+    const text = this.add.text(width - 16, height - 90, msg, {
       fontFamily: 'monospace',
       fontSize: '14px',
       color: '#ffffff',

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -680,6 +680,24 @@ html, body {
 }
 
 /* ═══════════════════════════════════════
+   LOBBY: ONLINE COUNT
+═══════════════════════════════════════ */
+#online-count {
+  font-size: 9px;
+  letter-spacing: 1.5px;
+  color: #666676;
+  text-align: center;
+  white-space: nowrap;
+  margin-bottom: 10px;
+  text-transform: uppercase;
+}
+#online-count .count-value {
+  color: #a8dadc;
+  font-weight: bold;
+  font-size: 11px;
+}
+
+/* ═══════════════════════════════════════
    LANDING SCREEN
 ═══════════════════════════════════════ */
 #landing-screen {

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -21,7 +21,7 @@ html, body {
 #game-container {
   display: none;
   width: 100vw; height: 100vh;
-  align-items: center; justify-content: center;
+  align-items: flex-start; justify-content: center;
 }
 #game-container canvas {
   image-rendering: pixelated;
@@ -315,7 +315,19 @@ html, body {
 
 /* ── Sub-options ── */
 .sub-options {
-  display: flex; flex-wrap: wrap; align-items: center; gap: 8px;
+  display: flex; flex-direction: column; gap: 10px;
+}
+
+.host-row {
+  display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+}
+.host-row .sub-label,
+.host-row .max-players-label {
+  min-width: 56px;
+}
+.host-row .game-mode-selector,
+.host-row .player-count-selector {
+  flex: 1;
 }
 
 .sub-btn {

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -270,18 +270,19 @@ html, body {
 
 /* ── Left: retro control panel ── */
 .lobby-control-panel {
-  width: 360px; flex-shrink: 0;
-  display: flex; flex-direction: column; justify-content: center;
-  gap: 22px;
-  padding: 36px 28px;
+  width: 720px; flex-shrink: 0;
+  display: flex; flex-direction: column; justify-content: flex-start;
+  gap: 14px;
+  padding: 20px 40px 16px;
   background: rgba(10, 10, 10, 0.62);
   border-right: 3px solid #1a1a1a;
+  overflow-y: auto;
 }
 
 .panel-title {
-  font-size: 24px; line-height: 1.5; letter-spacing: 2px;
+  font-size: 32px; line-height: 1.35; letter-spacing: 3px;
   color: #c41230;
-  text-shadow: 3px 3px 0 #000, -1px -1px 0 #7a0a1a;
+  text-shadow: 4px 4px 0 #000, -1px -1px 0 #7a0a1a;
 }
 
 .panel-divider {
@@ -297,9 +298,9 @@ html, body {
 }
 
 .mode-btn {
-  flex: 1; padding: 14px 0;
+  flex: 1; padding: 16px 0;
   background: #0d0d0d; border: none;
-  color: #666676; font-family: inherit; font-size: 10px;
+  color: #666676; font-family: inherit; font-size: 14px;
   letter-spacing: 2px; cursor: pointer;
   transition: background 0.1s, color 0.1s;
   text-transform: uppercase;
@@ -318,10 +319,10 @@ html, body {
 }
 
 .sub-btn {
-  padding: 9px 14px;
+  padding: 11px 18px;
   background: #0d0d0d; border: 2px solid #2a2a2a;
-  color: #666676; font-family: inherit; font-size: 8px;
-  letter-spacing: 1px; cursor: pointer;
+  color: #666676; font-family: inherit; font-size: 13px;
+  letter-spacing: 1.5px; cursor: pointer;
   transition: background 0.1s, color 0.1s, border-color 0.1s;
   text-transform: uppercase;
 }
@@ -340,7 +341,7 @@ html, body {
 
 /* Sub label */
 .sub-label {
-  font-size: 8px; letter-spacing: 1.5px; color: #666676; white-space: nowrap;
+  font-size: 12px; letter-spacing: 2px; color: #666676; white-space: nowrap;
 }
 
 /* Game mode selector */
@@ -352,14 +353,14 @@ html, body {
 }
 .game-mode-btn {
   flex: 1;
-  padding: 7px 10px;
+  padding: 10px 12px;
   background: #0d0d0d;
   border: none;
   border-right: 1px solid #2a2a2a;
   color: #666676;
   font-family: inherit;
-  font-size: 8px;
-  letter-spacing: 1px;
+  font-size: 12px;
+  letter-spacing: 1.5px;
   cursor: pointer;
   transition: background 0.1s, color 0.1s;
   text-transform: uppercase;
@@ -406,7 +407,7 @@ html, body {
 
 /* Max Players */
 .max-players-label {
-  font-size: 8px; letter-spacing: 1.5px; color: #666676; white-space: nowrap;
+  font-size: 12px; letter-spacing: 2px; color: #666676; white-space: nowrap;
 }
 
 .player-count-selector {
@@ -414,10 +415,10 @@ html, body {
 }
 
 .player-count-btn {
-  padding: 7px 10px;
+  padding: 10px 14px;
   background: #0d0d0d; border: none; border-right: 1px solid #2a2a2a;
-  color: #666676; font-family: inherit; font-size: 8px;
-  letter-spacing: 1px; cursor: pointer;
+  color: #666676; font-family: inherit; font-size: 12px;
+  letter-spacing: 1.5px; cursor: pointer;
   transition: background 0.1s, color 0.1s;
 }
 .player-count-btn:last-child { border-right: none; }
@@ -426,15 +427,15 @@ html, body {
 
 /* ── PLAY button ── */
 .play-btn {
-  width: 100%; padding: 18px 0;
+  width: 100%; padding: 20px 0;
   background: #ffd700;
   border: 3px solid #c9a800;
   box-shadow: 5px 5px 0 #7a6400;
-  color: #0a0a0a; font-family: inherit; font-size: 14px;
-  letter-spacing: 4px; cursor: pointer; text-transform: uppercase;
+  color: #0a0a0a; font-family: inherit; font-size: 20px;
+  letter-spacing: 5px; cursor: pointer; text-transform: uppercase;
   transition: filter 0.1s, transform 0.1s, box-shadow 0.1s;
   animation: pulse-play 1.8s steps(4) infinite;
-  margin-top: 6px;
+  margin-top: 0;
 }
 .play-btn:hover { filter: brightness(1.1); animation: none; }
 .play-btn:active { transform: translate(3px, 3px); box-shadow: 2px 2px 0 #7a6400; }
@@ -683,18 +684,18 @@ html, body {
    LOBBY: ONLINE COUNT
 ═══════════════════════════════════════ */
 #online-count {
-  font-size: 9px;
-  letter-spacing: 1.5px;
+  font-size: 13px;
+  letter-spacing: 2px;
   color: #666676;
   text-align: center;
   white-space: nowrap;
-  margin-bottom: 10px;
+  margin-bottom: 6px;
   text-transform: uppercase;
 }
 #online-count .count-value {
   color: #a8dadc;
   font-weight: bold;
-  font-size: 11px;
+  font-size: 16px;
 }
 
 /* ═══════════════════════════════════════

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -319,15 +319,31 @@ html, body {
 }
 
 .host-row {
-  display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: nowrap;
+  width: 100%;
+  min-width: 0;
 }
 .host-row .sub-label,
 .host-row .max-players-label {
-  min-width: 56px;
+  flex: 0 0 auto;
+  min-width: 64px;
+  white-space: nowrap;
 }
 .host-row .game-mode-selector,
 .host-row .player-count-selector {
-  flex: 1;
+  flex: 1 1 0;
+  min-width: 0;
+}
+.host-row .game-mode-btn,
+.host-row .player-count-btn {
+  flex: 1 1 0;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .sub-btn {
@@ -555,6 +571,9 @@ html, body {
 .stats-panel-inner {
   max-width: 720px; margin: 0 auto;
 }
+#leaderboard-panel .stats-panel-inner {
+  max-width: none; width: 100%;
+}
 .stats-panel-title {
   font-size: 18px; letter-spacing: 4px; color: #c41230;
   text-shadow: 3px 3px 0 #000;
@@ -638,6 +657,31 @@ html, body {
 }
 .leaderboard-table tr:hover td {
   background: #1a1a2e;
+}
+
+.leaderboard-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 20px;
+  align-items: start;
+}
+.leaderboard-col { min-width: 0; }
+.leaderboard-col-title {
+  font-size: 11px; letter-spacing: 3px; color: #c41230;
+  margin-bottom: 8px; padding-bottom: 6px;
+  border-bottom: 2px solid #c41230;
+  text-shadow: 2px 2px 0 #000;
+  text-align: center;
+}
+.leaderboard-grid .leaderboard-table { font-size: 10px; width: 100%; }
+.leaderboard-grid .leaderboard-table th,
+.leaderboard-grid .leaderboard-table td { padding: 6px 6px; }
+.leaderboard-empty {
+  color: #666; font-size: 9px; letter-spacing: 1px;
+  text-align: center; padding: 16px 8px;
+}
+@media (max-width: 900px) {
+  .leaderboard-grid { grid-template-columns: 1fr; }
 }
 
 .locker-grid {

--- a/my-server/prisma/schema.prisma
+++ b/my-server/prisma/schema.prisma
@@ -18,10 +18,23 @@ model User {
 
 model PlayerStats {
   clerkId     String   @id @map("clerk_id")
+
   totalKills  Int      @default(0) @map("total_kills")
   totalDeaths Int      @default(0) @map("total_deaths")
   totalGames  Int      @default(0) @map("total_games")
   totalWins   Int      @default(0) @map("total_wins")
+
+  ffaKills    Int      @default(0) @map("ffa_kills")
+  ffaDeaths   Int      @default(0) @map("ffa_deaths")
+  ffaGames    Int      @default(0) @map("ffa_games")
+  ffaWins     Int      @default(0) @map("ffa_wins")
+
+  kcConfirms  Int      @default(0) @map("kc_confirms")
+  kcKills     Int      @default(0) @map("kc_kills")
+  kcDeaths    Int      @default(0) @map("kc_deaths")
+  kcGames     Int      @default(0) @map("kc_games")
+  kcWins      Int      @default(0) @map("kc_wins")
+
   updatedAt   DateTime @updatedAt @map("updated_at")
   user        User     @relation(fields: [clerkId], references: [clerkId], onDelete: Cascade)
 

--- a/my-server/src/app.config.ts
+++ b/my-server/src/app.config.ts
@@ -12,6 +12,7 @@ import {
  * Import your Room files
  */
 import { MyRoom } from "./rooms/MyRoom.js";
+import { LobbyRoom } from "./rooms/LobbyRoom.js";
 import prisma from "./db.js";
 
 const server = defineServer({
@@ -20,7 +21,8 @@ const server = defineServer({
      * Define your room handlers:
      */
     rooms: {
-        my_room: defineRoom(MyRoom, { filterBy: ['isPrivate', 'gameMode'] })
+        my_room: defineRoom(MyRoom, { filterBy: ['isPrivate', 'gameMode'] }),
+        lobby_room: defineRoom(LobbyRoom)
     },
 
     /**
@@ -62,6 +64,18 @@ const server = defineServer({
             } catch (err) {
                 console.error("[api] /api/rooms error:", err);
                 res.json([]);
+            }
+        });
+
+        // Total online across lobby + game rooms
+        app.get("/api/online", async (_req, res) => {
+            try {
+                const rooms = await matchMaker.query({});
+                const total = rooms.reduce((sum: number, r: any) => sum + (r.clients || 0), 0);
+                res.json({ total });
+            } catch (err) {
+                console.error("[api] /api/online error:", err);
+                res.json({ total: 0 });
             }
         });
 

--- a/my-server/src/app.config.ts
+++ b/my-server/src/app.config.ts
@@ -120,12 +120,11 @@ const server = defineServer({
             }
         });
 
-        // Global leaderboard — top 20 players by total kills
+        // Global leaderboard — returns per-mode + overall stats; client sorts each column
         app.get("/api/leaderboard", async (_req: any, res: any) => {
             try {
                 const rows = await prisma.playerStats.findMany({
-                    take: 20,
-                    orderBy: { totalKills: 'desc' },
+                    take: 50,
                     include: { user: { select: { username: true } } },
                 });
                 res.json(rows.map((r: any) => ({
@@ -134,6 +133,15 @@ const server = defineServer({
                     total_deaths: r.totalDeaths,
                     total_wins:   r.totalWins,
                     total_games:  r.totalGames,
+                    ffa_kills:    r.ffaKills,
+                    ffa_deaths:   r.ffaDeaths,
+                    ffa_wins:     r.ffaWins,
+                    ffa_games:    r.ffaGames,
+                    kc_confirms:  r.kcConfirms,
+                    kc_kills:     r.kcKills,
+                    kc_deaths:    r.kcDeaths,
+                    kc_wins:      r.kcWins,
+                    kc_games:     r.kcGames,
                 })));
             } catch (err) {
                 console.error("[api] /api/leaderboard error:", err);

--- a/my-server/src/rooms/LobbyRoom.ts
+++ b/my-server/src/rooms/LobbyRoom.ts
@@ -1,0 +1,18 @@
+import { Room } from "colyseus";
+
+/**
+ * Lightweight presence room. Every client that lands on the lobby screen
+ * joins this room so the total online count includes lobby visitors, not
+ * just players already in a game. No state, no messages — purely presence.
+ */
+export class LobbyRoom extends Room {
+  maxClients = 200;
+
+  onCreate(): void {
+    this.autoDispose = true;
+  }
+
+  onJoin(): void {}
+
+  onLeave(): void {}
+}

--- a/my-server/src/rooms/MyRoom.ts
+++ b/my-server/src/rooms/MyRoom.ts
@@ -506,6 +506,31 @@ export class MyRoom extends Room {
       const won = this.gameMode === 'killConfirmed'
         ? (player.confirmedKills === topKills && topKills >= 0)
         : (player.kills === topKills && topKills >= 0);
+      const isKC     = this.gameMode === 'killConfirmed';
+      const kills    = player.kills;
+      const confirms = player.confirmedKills;
+      const deaths   = player.deaths;
+      const winInc   = won ? 1 : 0;
+
+      const modeCreate = isKC
+        ? { kcConfirms: confirms, kcKills: kills, kcDeaths: deaths, kcGames: 1, kcWins: winInc }
+        : { ffaKills: kills, ffaDeaths: deaths, ffaGames: 1, ffaWins: winInc };
+
+      const modeUpdate = isKC
+        ? {
+            kcConfirms: { increment: confirms },
+            kcKills:    { increment: kills },
+            kcDeaths:   { increment: deaths },
+            kcGames:    { increment: 1 },
+            kcWins:     { increment: winInc },
+          }
+        : {
+            ffaKills:  { increment: kills },
+            ffaDeaths: { increment: deaths },
+            ffaGames:  { increment: 1 },
+            ffaWins:   { increment: winInc },
+          };
+
       saves.push(
         (async () => {
           try {
@@ -520,19 +545,21 @@ export class MyRoom extends Room {
               where: { clerkId },
               create: {
                 clerkId,
-                totalKills: player.kills,
-                totalDeaths: player.deaths,
+                totalKills: kills,
+                totalDeaths: deaths,
                 totalGames: 1,
-                totalWins: won ? 1 : 0,
+                totalWins: winInc,
+                ...modeCreate,
               },
               update: {
-                totalKills:  { increment: player.kills },
-                totalDeaths: { increment: player.deaths },
+                totalKills:  { increment: kills },
+                totalDeaths: { increment: deaths },
                 totalGames:  { increment: 1 },
-                totalWins:   { increment: won ? 1 : 0 },
+                totalWins:   { increment: winInc },
+                ...modeUpdate,
               },
             });
-            console.log(`[stats] saved for ${player.name} — K:${player.kills} D:${player.deaths} W:${won}`);
+            console.log(`[stats] saved for ${player.name} — mode:${isKC ? 'KC' : 'FFA'} K:${kills} C:${confirms} D:${deaths} W:${won}`);
           } catch (err) {
             console.error(`[stats] failed for ${player.name}:`, err);
           }


### PR DESCRIPTION
## Summary
- Leaderboard tab now renders three side-by-side tables — **FREEPLAY**, **KILL CONFIRMED**, **OVERALL** — sortable independently. KC ranks by confirmed tags, Freeplay by kills, Overall by total kills. Panel spans the full width of the page.
- Per-mode stats tracking added: `PlayerStats` gains `ffa_*` and `kc_*` columns, `triggerEndGame()` increments the appropriate mode-specific counters in addition to the existing aggregates, and `/api/leaderboard` now returns the full per-mode payload.
- Host-option rows no longer let labels (MODE / MAX / TIME / ITEMS) bleed onto the previous row — `.host-row` uses `flex-wrap: nowrap` with `min-width: 0` on the row and its flex children, so buttons shrink with ellipsis instead of wrapping.
- Also bundles earlier branch work: collision-stuck recovery, live online-player count, landing page + bomb item + host duration/density options, Prisma 7 RDS connection fixes, iPad canvas/sidebar polish.

## Deploy notes
- Requires `npx prisma db push` on the RDS database after the EC2 `git pull` — new per-mode columns default to `0`, non-destructive, no data migration needed.
- Existing rows keep their aggregate totals in the OVERALL column; FFA and KC columns start at 0 and fill as new games are played.

## Test plan
- [ ] `cd client && npm run dev` → click HOST, verify each option row lays out as `[LABEL] [buttons]` on a single line even when the browser is narrowed.
- [ ] Against a local Postgres (`createdb campusclash_dev`, point `my-server/.env` at it, `npx prisma db push`, `npm start`): play one Freeplay and one Kill Confirmed game, open Leaderboard tab, confirm each mode table populates the correct player / counts.
- [ ] Confirm Leaderboard panel fills the full width (not capped at 720px).
- [ ] Confirm the aggregate `/api/stats/:clerkId` endpoint is unchanged and the single-player stats panel still renders normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)